### PR TITLE
Migrate to Selenium 4

### DIFF
--- a/bin/scripts/WebDriver.js
+++ b/bin/scripts/WebDriver.js
@@ -14,16 +14,14 @@ module.exports = class WebDriver {
 
         this.timeout = timeout;
         this.driver = builder.build();
-        this.action = new webdriver.ActionSequence(this.driver);
     }
 
     initialize() {
-        const timeouts = this.driver.manage().timeouts();
-        return Promise.all([
-            timeouts.implicitlyWait(this.timeout),
-            timeouts.pageLoadTimeout(this.timeout),
-            timeouts.setScriptTimeout(this.timeout),
-        ]);
+        return this.driver.manage().setTimeouts({
+            implicit: this.timeout,
+            pageLoad: this.timeout,
+            script: this.timeout,
+        });
     }
 
     trigger(event, selector) {

--- a/bin/scripts/WebDriver.js
+++ b/bin/scripts/WebDriver.js
@@ -6,7 +6,7 @@ module.exports = class WebDriver {
     constructor(path, timeout) {
         const options = new chrome.Options();
         options.addArguments("no-sandbox");
-        options.addExtensions(path);
+        options.addArguments("load-extension=" + path);
 
         const builder = new webdriver.Builder();
         builder.forBrowser("chrome");
@@ -22,9 +22,5 @@ module.exports = class WebDriver {
             pageLoad: this.timeout,
             script: this.timeout,
         });
-    }
-
-    trigger(event, selector) {
-        return this.driver.executeScript("$('" + selector + "').trigger('" + event + "')");
     }
 };

--- a/bin/test
+++ b/bin/test
@@ -14,13 +14,8 @@ const WebDriver = require("./scripts/WebDriver");
             throw new Error("Username or password must be specified.");
         }
 
-        // Create package
-        const extension = new ChromeExtension("src/*");
-        const filename = await extension.byCrx();
-        console.log("Test: Package is generated.");
-
         // Initialize
-        const test = new WebDriver(filename, 30000);
+        const test = new WebDriver(await fs.realpath("src"), 30000);
         await test.initialize();
 
         await test.driver.get("https://tweetdeck.twitter.com");
@@ -51,47 +46,66 @@ const WebDriver = require("./scripts/WebDriver");
         const main = await test.driver.findElement(By.css(".application"));
 
         // Since the app is loaded, shorten timeout value.
-        await test.driver.manage().timeouts().implicitlyWait(0);
+        await test.driver.manage().setTimeouts({
+            implicit: 0,
+        });
         console.log("Test: Application is loaded.");
 
         for (let i = 0; i < 5; i++) {
             console.log(`Test: New Tweet (${i + 1}/5)`);
 
             // New Tweet button
-            await test.trigger("click", ".js-show-drawer.btn-compose");
+            const button = await test.driver.findElement(By.css(".js-show-drawer.btn-compose"));
+            await button.click();
+
+            // Wait until the buttons become available
+            await test.driver.wait(until.elementLocated(By.css(".js-send-button")), test.timeout);
 
             for (let j = 0; j < 50; j++) {
                 const accounts = await main.findElements(By.css(".js-account-list .js-account-item"));
                 const target = accounts[Math.floor(Math.random() * accounts.length)];
                 const key = await target.getAttribute("data-account-key");
-                await test.trigger("click", `.js-account-item[data-account-key="${key}"]`)
+                const item = await test.driver.findElement(By.css(`.js-account-item[data-account-key="${key}"]`));
+                await item.click();
 
                 const current = await main.findElements(By.css(".js-account-list .js-account-item.is-selected"));
                 assert(current.length <= 1);
             }
 
             // Close Tweet drawer
-            await test.trigger("click", ".js-drawer-close");
+            const closer = await test.driver.findElement(By.css(".js-drawer-close"));
+            await closer.click();
         }
+
+        // Reopen Tweet drawer
+        const button = await test.driver.findElement(By.css(".js-show-drawer.btn-compose"));
+        await button.click();
+        await test.driver.wait(until.elementLocated(By.css(".js-show-drawer.btn-compose.is-hidden")), test.timeout);
 
         for (let i = 0; i < 5; i++) {
             console.log(`Test: Retweet (${i + 1}/5)`);
 
             // Open Retweet modal
-            await test.trigger("click", "a.tweet-action[rel=retweet]");
+            const retweet = await test.driver.findElement(By.css("a.tweet-action[rel=retweet]"));
+            await retweet.click();
+
+            // Wait until the dialog becomes available
+            await test.driver.wait(until.elementLocated(By.css(".js-retweet-button")), test.timeout);
 
             for (let j = 0; j < 50; j++) {
                 const accounts = await main.findElements(By.css("ul.js-account-selector li.js-account-item"));
                 const target = accounts[Math.floor(Math.random() * accounts.length)];
                 const id = await target.getAttribute("data-id");
-                await test.trigger("click", `li.js-account-item[data-id="${id}"]`);
+                const item = await test.driver.findElement(By.css(`li.js-account-item[data-id="${id}"]`));
+                await item.click();
 
                 const current = await main.findElements(By.css("li.acc-selected"));
                 assert(current.length <= 1);
             }
 
             // Close Retweet modal
-            await test.trigger("click", ".js-dismiss");
+            const closer = await test.driver.findElement(By.css(".js-dismiss"));
+            await closer.click();
         }
 
         await test.driver.quit();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tweetdeck-accounts-switcher",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -284,9 +284,9 @@
       }
     },
     "chromedriver": {
-      "version": "2.34.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.34.1.tgz",
-      "integrity": "sha512-ivXrPKKtnX442J8Lkbhb8hJ5+lelzAqrAI9VjVs3/iujm396JnJYXGGGjniPXvQeLVE3HDIWwsHu8goIUq3rMQ==",
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.35.0.tgz",
+      "integrity": "sha512-zqvC/HKybRxiM68GzByvUaXxTmNCmpETvLQIM92IEdrQxPnONKt3ZdTsiwxmGrL2ZIDbr9OEHJljmhZZMEsFPw==",
       "dev": true,
       "requires": {
         "del": "3.0.0",
@@ -492,9 +492,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz",
-      "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.16.0.tgz",
+      "integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -1606,9 +1606,9 @@
       "dev": true
     },
     "selenium-webdriver": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
-      "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
+      "version": "4.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.1.tgz",
+      "integrity": "sha512-z88rdjHAv3jmTZ7KSGUkTvo4rGzcDGMq0oXWHNIDK96Gs31JKVdu9+FMtT4KBrVoibg8dUicJDok6GnqqttO5Q==",
       "dev": true,
       "requires": {
         "jszip": "3.1.5",

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   "devDependencies": {
     "child-process-promise": "^2.2.1",
     "chrome-extension-deploy": "^3.0.0",
-    "chromedriver": "^2.34.1",
-    "eslint": "^4.15.0",
+    "chromedriver": "^2.35.0",
+    "eslint": "^4.16.0",
     "glob": "^7.1.2",
     "glob-promise": "^3.3.0",
     "mz": "^2.7.0",
     "node-zip": "^1.1.1",
-    "selenium-webdriver": "^3.6.0"
+    "selenium-webdriver": "^4.0.0-alpha.1"
   },
   "optionalDependencies": {
     "regedit": "^2.2.7"


### PR DESCRIPTION
- Replaces `chrome.Options#addExtensions` by the `--load-extension` parameter. The old method no longer works though it still seems supported.
- Removes `webdriver.ActionSequence` (not used any more)
- Replaces `Options#timeouts` by `Options#setTimeouts`
- Removes `WebDriver#trigger` now that Chrome driver handles `click` event properly. Adds some processes in order that the driver can precisely find elements.