### PR TITLE
Remove ChromeExtension#byCrx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,7 @@ before_script:
   - bin/.travis/before_script
 
 script:
-  - npm run lint
-  - npm test
+  - bin/.travis/script
 
 after_success:
   - bin/.travis/after_success

--- a/bin/.travis/script
+++ b/bin/.travis/script
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+npm run lint
+
+if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then
+    npm test
+fi

--- a/bin/scripts/ChromeExtension.js
+++ b/bin/scripts/ChromeExtension.js
@@ -1,6 +1,4 @@
-const os = require("os");
 const path = require("path");
-const spawn = require("child-process-promise").spawn;
 const fs = require("mz/fs");
 const glob = require("glob-promise");
 const JSZip = require("node-zip");
@@ -8,71 +6,6 @@ const JSZip = require("node-zip");
 module.exports = class ChromeExtension {
     constructor(target) {
         this.target = target || "*.{js,png,json}";
-    }
-
-    findWin32Registry(key) {
-        return new Promise((resolve, reject) => {
-            const data = new Map();
-            require("regedit").list([ key ])
-                              .on("data", entry => data.set(entry.key, entry.data))
-                              .on("error", e => reject(e))
-                              .on("finish", () => resolve(data));
-        });
-    }
-
-    async getChromePath() {
-        switch (os.platform()) {
-            case "linux": {
-                return "/usr/bin/google-chrome";
-            }
-            case "darwin": {
-                return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
-            }
-            case "win32": {
-                const path = "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\chrome.exe";
-                for (const [ key, { values } ] of await this.findWin32Registry(path)) {
-                    return values[""].value;
-                }
-            }
-        }
-    }
-
-    async byCrx() {
-        const chrome = await this.getChromePath();
-        if (!chrome) {
-            throw new Error("This operating system is not supported");
-        }
-
-        // Remove the files which were already generated
-        try {
-            await Promise.all([
-                fs.unlink("target.crx"),
-                fs.unlink("target.pem"),
-                fs.mkdir("target"),
-            ]);
-        } catch (e) {
-            // No problem if fails
-        }
-
-        // Copy files to the destination directory
-        await Promise.all(
-            await glob(this.target, { nodir: true }).then(files =>
-                files.map(filename =>
-                    fs.copyFile(
-                        filename,
-                        path.join("target", path.basename(filename)),
-                    ),
-                ),
-            ),
-        );
-
-        await spawn(chrome, ["--pack-extension=" + path.resolve("target")]);
-        await fs.unlink("target.pem");
-        if (!await fs.exists("target.crx")) {
-            throw new Error("The extension was not created.");
-        }
-
-        return fs.realpath("target.crx");
     }
 
     async byZip(destination) {

--- a/bin/scripts/WebDriver.js
+++ b/bin/scripts/WebDriver.js
@@ -1,6 +1,5 @@
 const webdriver = require("selenium-webdriver");
 const chrome = require("selenium-webdriver/chrome");
-const chromedriver = require("chromedriver");
 
 module.exports = class WebDriver {
     constructor(path, timeout) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -263,17 +263,6 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
-    "child-process-promise": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-2.2.1.tgz",
-      "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "4.0.2",
-        "node-version": "1.1.0",
-        "promise-polyfill": "6.1.0"
-      }
-    },
     "chrome-extension-deploy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chrome-extension-deploy/-/chrome-extension-deploy-3.0.0.tgz",
@@ -386,16 +375,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.3.0"
-      }
     },
     "cryptiles": {
       "version": "3.1.2",
@@ -949,8 +928,7 @@
     "if-async": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/if-async/-/if-async-3.7.4.tgz",
-      "integrity": "sha1-VYaN6wCT08Z79xZudFNT+5vLIaI=",
-      "optional": true
+      "integrity": "sha1-VYaN6wCT08Z79xZudFNT+5vLIaI="
     },
     "ignore": {
       "version": "3.3.7",
@@ -1267,12 +1245,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "node-version": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.1.0.tgz",
-      "integrity": "sha512-t1V2RFiaTavaW3jtQO0A2nok6k7/Gghuvx2rjvICuT0B0dYaObBQ4U0xHL+ZTPFZodt1LMYG2Vi2nypfz4/AJg==",
-      "dev": true
-    },
     "node-zip": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",
@@ -1413,12 +1385,6 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
-    "promise-polyfill": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
-      "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=",
-      "dev": true
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1456,7 +1422,6 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/regedit/-/regedit-2.2.7.tgz",
       "integrity": "sha1-RwKEh6RxqqfWKo0Dg8zu7evzr4A=",
-      "optional": true,
       "requires": {
         "debug": "2.6.1",
         "if-async": "3.7.4",
@@ -1731,8 +1696,7 @@
     "stream-slicer": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stream-slicer/-/stream-slicer-0.0.6.tgz",
-      "integrity": "sha1-+GsqxcJEC3oKh7cfM2ZcB4gEYTg=",
-      "optional": true
+      "integrity": "sha1-+GsqxcJEC3oKh7cfM2ZcB4gEYTg="
     },
     "string-width": {
       "version": "2.1.1",
@@ -1850,7 +1814,6 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "optional": true,
       "requires": {
         "readable-stream": "1.0.34",
         "xtend": "4.0.1"
@@ -1859,14 +1822,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "optional": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -1997,8 +1958,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "optional": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/chitoku-k/TweetDeckAccountsSwitcher#readme",
   "devDependencies": {
-    "child-process-promise": "^2.2.1",
     "chrome-extension-deploy": "^3.0.0",
     "chromedriver": "^2.35.0",
     "eslint": "^4.16.0",
@@ -31,8 +30,5 @@
     "mz": "^2.7.0",
     "node-zip": "^1.1.1",
     "selenium-webdriver": "^4.0.0-alpha.1"
-  },
-  "optionalDependencies": {
-    "regedit": "^2.2.7"
   }
 }


### PR DESCRIPTION
Removes `ChromeExtension#byCrx` and its related dependencies as this feature is no longer needed. Chrome Extension is now loaded over the directory.